### PR TITLE
Feature/pn claw to apl method

### DIFF
--- a/bindings/python/pyolfsysm.cpp
+++ b/bindings/python/pyolfsysm.cpp
@@ -65,10 +65,13 @@ PYBIND11_MODULE(olfsysm, m) {
         .def_readwrite("inhsc", &ModelParams::PN::inhsc)
         .def_readwrite("inhadd", &ModelParams::PN::inhadd)
         .def_readwrite("noise", &ModelParams::PN::noise)
+        .def_readwrite("apl_taum", &ModelParams::PN::apl_taum)
+        .def_readwrite("tau_apl2pn", &ModelParams::PN::tau_apl2pn)
         .def_readwrite("Btn_num_per_glom", &ModelParams::PN::Btn_num_per_glom)
+        .def_readwrite("pn_apl_tune", &ModelParams::PN::pn_apl_tune)
         .def_readwrite("preset_Btn", &ModelParams::PN::preset_Btn)
-        .def_readwrite("preset_wAPLBtn", &ModelParams::PN::preset_wAPLBtn)
-        .def_readwrite("preset_wBtnAPL", &ModelParams::PN::preset_wBtnAPL);
+        .def_readwrite("preset_wAPLPN", &ModelParams::PN::preset_wAPLPN) 
+        .def_readwrite("preset_wPNAPL", &ModelParams::PN::preset_wPNAPL);
 
     py::class_<ModelParams::PN::Noise>(m, "MPPNNoise")
         .def_readwrite("mean", &ModelParams::PN::Noise::mean)
@@ -99,6 +102,8 @@ PYBIND11_MODULE(olfsysm, m) {
         .def_readwrite("tune_apl_weights", &ModelParams::KC::tune_apl_weights)
         .def_readwrite("preset_wAPLKC", &ModelParams::KC::preset_wAPLKC)
         .def_readwrite("preset_wKCAPL", &ModelParams::KC::preset_wKCAPL)
+        .def_readwrite("zero_wAPLKC", &ModelParams::KC::zero_wAPLKC)
+        .def_readwrite("pn_claw_to_APL", &ModelParams::KC::pn_claw_to_APL)
         .def_readwrite("ignore_ffapl", &ModelParams::KC::ignore_ffapl)
         .def_readwrite("fixed_thr", &ModelParams::KC::fixed_thr)
         .def_readwrite("add_fixed_thr_to_spont", &ModelParams::KC::add_fixed_thr_to_spont)
@@ -115,6 +120,7 @@ PYBIND11_MODULE(olfsysm, m) {
         .def_readwrite("tune_from", &ModelParams::KC::tune_from)
         .def_readwrite("apltune_subsample", &ModelParams::KC::apltune_subsample)
         .def_readwrite("taum", &ModelParams::KC::taum)
+        .def_readwrite("apl_Cm", &ModelParams::KC::apl_Cm)
         .def_readwrite("apl_taum", &ModelParams::KC::apl_taum)
         .def_readwrite("tau_apl2kc", &ModelParams::KC::tau_apl2kc)
         .def_readwrite("tau_r", &ModelParams::KC::tau_r)
@@ -167,6 +173,8 @@ PYBIND11_MODULE(olfsysm, m) {
     py::class_<RunVars::PN>(m, "RVPN")
         .def_readwrite("pn_to_Btns", &RunVars::PN::pn_to_Btns)
         .def_readwrite("Btn_to_pn", &RunVars::PN::Btn_to_pn)
+        .def_readwrite("wAPLPN", &RunVars::PN::wAPLPN) 
+        .def_readwrite("wPNAPL", &RunVars::PN::wPNAPL) 
         .def_readwrite("pn_sims", &RunVars::PN::sims);
 
     py::class_<RunVars::FFAPL>(m, "RVFFAPL")
@@ -195,8 +203,6 @@ PYBIND11_MODULE(olfsysm, m) {
         .def_readwrite("kc_to_claws", &RunVars::KC::kc_to_claws)
         .def_readwrite("claw_compartments", &RunVars::KC::claw_compartments)
         .def_readwrite("compartment_to_claws", &RunVars::KC::compartment_to_claws)
-        .def_readwrite("wAPLBtn", &RunVars::KC::wAPLBtn)
-        .def_readwrite("wBtnAPL", &RunVars::KC::wBtnAPL)
         ;
 
     m.def("load_hc_data", &load_hc_data, R"pbdoc(
@@ -252,3 +258,4 @@ PYBIND11_MODULE(olfsysm, m) {
     m.attr("__version__") = "dev";
 #endif
 }
+

--- a/libolfsysm/api/olfsysm.hpp
+++ b/libolfsysm/api/olfsysm.hpp
@@ -281,9 +281,11 @@ struct ModelParams {
         bool save_nves_sims;
         bool save_inh_sims;
         bool save_Is_sims;
+        bool save_claw_sims;
 
         std::vector<long long> kc_ids;
         bool wPNKC_one_row_per_claw;
+        bool allow_net_inh_per_claw;
     } kc;
 
     /* Feedforward APL params. */
@@ -443,6 +445,8 @@ struct RunVars {
         /* Timeseries of KC->APL synapse current for each odor. */
         std::vector<Row> Is_sims;
 
+        std::vector<Matrix> claw_sims;
+
         /* The number of iterations done during APL tuning. */
         unsigned tuning_iters;
 
@@ -519,7 +523,7 @@ void sim_FFAPL_layer(
 void sim_KC_layer(
         ModelParams const& p, RunVars const& rv,
         Matrix const& pn_t, Vector const& ffapl_t,
-        Matrix& Vm, Matrix& spikes, Matrix& nves, Row& inh, Row& Is);
+        Matrix& Vm, Matrix& spikes, Matrix& nves, Row& inh, Row& Is, Matrix& claw_sims);
 
 /* Run ORN and LN sims for all odors. */
 void run_ORN_LN_sims(ModelParams const& p, RunVars& rv);


### PR DESCRIPTION
** All the newly introduced variables in model parameters and RunVar are initialized to be 0 or false; 

1). Claw_to_apl method: I introduced a method to have claw directly interact with APL in the `sim_KC_layer` function, specifically in the branches where `wPNKC_one_row_per_claw` is true. This involves several new variables: 1). in order for this to work, I would have to enforce that in threshold determination step, `wAPLKC` and `wKCAPL` is 0. Therefore, when this `pn_claw_to_APL` is true in `mb_model.py`, I would have `p.kc.zero_wAPLKC` and `p.kc.pn_claw_to_APL` turn on as well. The `zero_wAPLKC` method happens in `fit_sparseness` . It would first store a `temp_wAPLKC` and `temp_wKCAPL`, zero the original weight matrices, and after initial vector determination call of `sim_KC_layer` , give the original values of `wAPLKC` and `wKCAPL` back. Note that this is currently only working in the `use_connectome_APL_weights` is true method. In `sim_KC_layer` , when we use the `pn_claw_to_APL` method, instead of getting claw→APL drive through dividing `kc_activity` to their claws (which relies on KC spiking), we will take claw→APL drive through `pn_t` (PN activity). This to a higher degree reconstructs the claw→KC interaction. 

2). PN_APL interaction: a). I changed most of the variable names related to PN↔APL interactions to `wPNAPL` and `wAPLPN` since I felt that it makes more sense then calling it `wBtnAPL` (we may consider having `wPNAPL` without the presence of boutons, so I chose `PN` for consistency with `wAPLKC`). b). If `p.pn.pn_apl_tune` is true, then we will have `pn_to_apl` and `apl_to_pn` interactions in similar ways as KC and APL. At the moments, all the weights should be zeroed so even if `pn_to_apl` is true, there will be no change in result.